### PR TITLE
Rename web.config rules for better understanding

### DIFF
--- a/web.config
+++ b/web.config
@@ -3,11 +3,11 @@
     <system.webServer>
         <rewrite>
       <rules>
-          <rule name="Imported Rule 1">
+          <rule name="rewrite everything to /public">
             <match url="^/public/(.*)$" ignoreCase="true" negate="true" />
             <action type="Rewrite" url="/public{REQUEST_URI}" />
         </rule>
-        <rule name="Imported Rule 2" stopProcessing="true">
+        <rule name="route all requests to non-existing files through index.php" stopProcessing="true">
           <match url=".*" ignoreCase="true" />
            <conditions>
             <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />


### PR DESCRIPTION
Instead of the htaccess-converter generated names we use some that are easier to understand

While looking through some projects for hacktoberfest I stumbled upon this, well not really a bug but more like an inconvenience. 
Not having to deal with apache or iis configurations that much myself but still wanting to know what it actually does, I felt it would be a small and nice change that you may appreciate.